### PR TITLE
Help Desk: Update front matter for GitHub Management Policy templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/ISSUE_TEMPLATE_REPOSITORY_CREATION_REQUEST.md
+++ b/.github/ISSUE_TEMPLATE/ISSUE_TEMPLATE_REPOSITORY_CREATION_REQUEST.md
@@ -1,8 +1,9 @@
 ---
-name: "Request New Repository"
-description: "Request the creation of a new repository under DSACMS."
-labels: ["help-desk", "repo-request", "repo-management"]
-assignees: []
+name: Request New Repository
+about: Request the creation of a new repository under DSACMS
+title: Request New Repository
+labels: ["helpdesk", "repo-request", "repo-management"]
+assignees: @dsac-ospo
 ---
 
 ## Request a New Repository

--- a/.github/ISSUE_TEMPLATE/ISSUE_TEMPLATE_REPOSITORY_CREATION_REQUEST.md
+++ b/.github/ISSUE_TEMPLATE/ISSUE_TEMPLATE_REPOSITORY_CREATION_REQUEST.md
@@ -1,9 +1,9 @@
 ---
 name: Request New Repository
 about: Request the creation of a new repository under DSACMS
-title: Request New Repository
+title: "[REQUEST]: New Repository"
 labels: ["helpdesk", "repo-request", "repo-management"]
-assignees: @dsac-ospo
+assignees: "@dsac-ospo"
 ---
 
 ## Request a New Repository

--- a/.github/ISSUE_TEMPLATE/ISSUE_TEMPLATE_TEAM_ACCESS_REQUEST.md
+++ b/.github/ISSUE_TEMPLATE/ISSUE_TEMPLATE_TEAM_ACCESS_REQUEST.md
@@ -1,8 +1,9 @@
 ---
-name: "Request Team Access"
-description: "Request access to a team as a member."
-labels: ["help-desk", "access-request", "team-management"]
-assignees: []
+name: Request Team Access
+about: Request access to a team as a member
+title: Request Team Access
+labels: ["helpdesk", "access-request", "team-management"]
+assignees: @dsac-ospo
 ---
 
 ## Requesting Access to a Team as a Member

--- a/.github/ISSUE_TEMPLATE/ISSUE_TEMPLATE_TEAM_ACCESS_REQUEST.md
+++ b/.github/ISSUE_TEMPLATE/ISSUE_TEMPLATE_TEAM_ACCESS_REQUEST.md
@@ -1,7 +1,7 @@
 ---
 name: Request Team Access
 about: Request access to a team as a member
-title: "[REQUEST]: "
+title: "[REQUEST]: Team Access"
 labels: ["helpdesk", "access-request", "team-management"]
 assignees: "@dsac-ospo"
 ---

--- a/.github/ISSUE_TEMPLATE/ISSUE_TEMPLATE_TEAM_ACCESS_REQUEST.md
+++ b/.github/ISSUE_TEMPLATE/ISSUE_TEMPLATE_TEAM_ACCESS_REQUEST.md
@@ -1,9 +1,9 @@
 ---
 name: Request Team Access
 about: Request access to a team as a member
-title: Request Team Access
+title: "[REQUEST]: "
 labels: ["helpdesk", "access-request", "team-management"]
-assignees: @dsac-ospo
+assignees: "@dsac-ospo"
 ---
 
 ## Requesting Access to a Team as a Member

--- a/.github/ISSUE_TEMPLATE/ISSUE_TEMPLATE_TEAM_CREATION_REQUEST.md
+++ b/.github/ISSUE_TEMPLATE/ISSUE_TEMPLATE_TEAM_CREATION_REQUEST.md
@@ -1,9 +1,9 @@
 ---
 name: Request New Team
 about: Request the creation of new teams for a project
-title: Request New Team
+title: "[REQUEST]: New Team"
 labels: ["helpdesk", "team-request", "team-management"]
-assignees: @dsac-ospo
+assignees: "@dsac-ospo"
 ---
 
 ## Request New Teams for a Project

--- a/.github/ISSUE_TEMPLATE/ISSUE_TEMPLATE_TEAM_CREATION_REQUEST.md
+++ b/.github/ISSUE_TEMPLATE/ISSUE_TEMPLATE_TEAM_CREATION_REQUEST.md
@@ -1,8 +1,9 @@
 ---
-name: "Request New Team"
-description: "Request the creation of new teams for a project."
-labels: ["help-desk", "team-request", "team-management"]
-assignees: []
+name: Request New Team
+about: Request the creation of new teams for a project
+title: Request New Team
+labels: ["helpdesk", "team-request", "team-management"]
+assignees: @dsac-ospo
 ---
 
 ## Request New Teams for a Project


### PR DESCRIPTION
## Problem
Issue templates were missing certain front-matter fields and values

## Solution
- Added required `about` field 
- Added `title` field
- Updated label to `helpdesk`
- Assignee set to `dsac-ospo` team 